### PR TITLE
fix(userTask): use the proper filter name

### DIFF
--- a/src/main/java/org/bonitasoft/web/client/services/impl/DefaultProcessService.java
+++ b/src/main/java/org/bonitasoft/web/client/services/impl/DefaultProcessService.java
@@ -215,7 +215,7 @@ public class DefaultProcessService extends AbstractService implements ProcessSer
                 .get(UserTaskApi.class)
                 .searchUserTasks(
                         new UserTaskApi.SearchUserTasksQueryParams()
-                                .f(singletonList("rootContainerId=" + rootContainerId)));
+                                .f(singletonList("rootCaseId=" + rootContainerId)));
         log.debug("Found User Tasks: {}", userTasks);
         return userTasks;
     }


### PR DESCRIPTION
Use the `rootCaseId` filter name instead of `rootContainerId`