### PR TITLE
feat(redirect): disable follow redirect

### DIFF
--- a/src/main/java/org/bonitasoft/web/client/BonitaClientBuilder.java
+++ b/src/main/java/org/bonitasoft/web/client/BonitaClientBuilder.java
@@ -39,6 +39,15 @@ public interface BonitaClientBuilder<T extends BonitaClientBuilder> {
      * @return the current builder
      */
     T writeTimeoutInSeconds(int writeTimeoutInSeconds);
+    
+    /**
+     * Configure whether the client should follow HTTP redirections.
+     * Disabled by default.
+     *
+     * @param followRedirects
+     * @return the current builder
+     */
+    T followRedirects(boolean followRedirects);
 
     /**
      * disable certificate check, trust all certs as default

--- a/src/test/resources/application.xml
+++ b/src/test/resources/application.xml
@@ -1,6 +1,6 @@
 <applications xmlns="http://documentation.bonitasoft.com/application-xml-schema/1.0">
     <application profile="User" state="ACTIVATED" token="HR-dashboard_Client_tests" version="2.0" homePage="my-new-custom-page"
-                 layout="custompage_defaultlayout" theme="custompage_bootstrapdefaulttheme">
+                 layout="custompage_layoutBonita" theme="custompage_themeBonita">
 
         <displayName>My HR dashboard</displayName>
         <description>This is the HR dashboard.</description>
@@ -22,8 +22,8 @@
             </applicationMenu>
         </applicationMenus>
     </application>
-    <application state="ACTIVATED" token="MyApplication_Client_tests" version="2.0" layout="custompage_defaultlayout"
-                 theme="custompage_bootstrapdefaulttheme">
+    <application state="ACTIVATED" token="MyApplication_Client_tests" version="2.0" layout="custompage_layoutBonita"
+                 theme="custompage_themeBonita">
 
         <displayName>Marketing</displayName>
         <applicationPages/>


### PR DESCRIPTION
Disable `followRedirects` by default and add a configuration options.
This can have an impact if a user was expecting a http -> https
redirection.
Feign request options was not inheriting from the okhttp configuration
for timeouts.

Fix BonitaClientIT as default layout and bootstrap theme are not
included in the bundle by default anymore.