### PR TITLE
fix(feign): disable 404 decoder

### DIFF
--- a/src/main/java/org/bonitasoft/web/client/feign/BonitaFeignClientBuilderImpl.java
+++ b/src/main/java/org/bonitasoft/web/client/feign/BonitaFeignClientBuilderImpl.java
@@ -150,7 +150,6 @@ public class BonitaFeignClientBuilderImpl implements BonitaFeignClientBuilder {
                 .options(new Request.Options(okHttpClient.connectTimeoutMillis(), TimeUnit.MILLISECONDS,
                         okHttpClient.readTimeoutMillis(), TimeUnit.MILLISECONDS,
                         okHttpClient.followRedirects()))
-                .decode404()
                 .decoder(
                         new DelegatingDecoder().register("application/json", new JacksonDecoder(objectMapper)))
                 // Map feign exception to ours


### PR DESCRIPTION
404 response are handled in the BonitaErrorDecoder and throws
`NotFoundExcpetion` which is the expected behavior.

Enabling 404 decoder returns empty instances which is confusing.