### PR TITLE
tr(gh-action): replace deprecated github action create-release

### DIFF
--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: maven
-          
+
       # Extract version
       - name: Extract version
         shell: bash
@@ -34,37 +34,32 @@ jobs:
           gpg_passphrase: ${{ secrets.gpg_passphrase }}
           nexus_username: ${{ secrets.ossrh_username }}
           nexus_password: ${{ secrets.ossrh_password }}
-       
-      # Create tag and GitHub release 
+
+      # Create tag and GitHub release
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.extract_version.outputs.version }}
-          release_name: Release ${{ steps.extract_version.outputs.version }}
-          body: |
-            TODO
-          draft: false
-          prerelease: false
-          
+          tag: ${{ steps.extract_version.outputs.version }}
+          name: Release ${{ steps.extract_version.outputs.version }}
+          generateReleaseNotes: true
+
       # Switch to dev  
       - uses: actions/checkout@v3
         with:
           ref: 'dev'
-                
-      # Merge master into dev    
+
+      # Merge master into dev
       - uses: everlytic/branch-merge@1.1.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_ref: 'master'
           target_branch: 'dev'
           commit_message_template: 'ci(release): Merge master into dev'
-          
+
       # Update next dev version
       - name: Git pull
-        run: | 
+        run: |
           git config pull.rebase false 
           git pull
       - name: Update next version
@@ -78,12 +73,9 @@ jobs:
         run: ./set-version.sh ${{ steps.extract_next_version.outputs.next_version }}
         id: set_next_version
       - name: Commit next version
-        run: | 
+        run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add --all
           git commit -m "ci(release): Set next dev version"
           git push
-
-         
-         


### PR DESCRIPTION
actions/create-release is not maintained anymore and is running on deprecated Node12 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

[JIRA CI-775](https://bonitasoft.atlassian.net/browse/CI-775)