### PR TITLE
fix(update): Application update must also replace application links.

### DIFF
--- a/src/main/java/org/bonitasoft/web/client/services/impl/DefaultApplicationService.java
+++ b/src/main/java/org/bonitasoft/web/client/services/impl/DefaultApplicationService.java
@@ -92,7 +92,14 @@ public class DefaultApplicationService extends AbstractService implements Applic
         List<String> tokens = new ArrayList<>();
         final XmlDocumentParser documentParser = new XmlDocumentParser();
         Document doc = documentParser.parse(application);
+        // find legacy applications
         NodeList nodeList = documentParser.queryNodeList(doc, "/applications/application/@token");
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            Node item = nodeList.item(i);
+            tokens.add(item.getNodeValue());
+        }
+        // find application links
+        nodeList = documentParser.queryNodeList(doc, "/applications/applicationLink/@token");
         for (int i = 0; i < nodeList.getLength(); i++) {
             Node item = nodeList.item(i);
             tokens.add(item.getNodeValue());


### PR DESCRIPTION
Now that Application Links are compatible with platform mode, we must also delete them silently when updating, just like legacy apps.

Relates to [BPM-274](https://bonitasoft.atlassian.net/browse/BPM-274)

[BPM-274]: https://bonitasoft.atlassian.net/browse/BPM-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ