### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ endif::[]
 :uri-contribute: {uri-rel-file-base}CONTRIBUTING.adoc
 :uri-license: {uri-rel-file-base}LICENSE.md
 
-image::Bonitasoft_Community_RGB.png[Bonitasoft,link="https://www.bonitasoft.com",width=450px]
+image::Bonitasoft_Community_RGB.png[Bonitasoft,link="https://www.ofelia.com",width=450px]
 
 ifdef::status[]
 image:{uri-repo}/workflows/workflow-build/badge.svg[Build,link="{uri-repo}/actions?query=workflow%3Aworkflow-build"]
@@ -363,7 +363,7 @@ endif::[]
 - Repository: https://github.com/bonitasoft/{project-artifact-id}/
 - Issue tracker: https://github.com/bonitasoft/{project-artifact-id}/issues. +
   In case of sensitive bugs like security vulnerabilities, please contact rd@bonitasoft.com directly instead of using issue tracker. We value your effort to improve the security and privacy of this project!
-- Current Bonita REST API documentation: https://documentation.bonitasoft.com/bonita/{bonita-short-version}/rest-api-overview
+- Current Bonita REST API documentation: https://documentation.ofelia.com/bonita/{bonita-short-version}/rest-api-overview
 - OpenAPI specification: https://swagger.io/specification/
 - OpenAPI generator: https://github.com/OpenAPITools/openapi-generator
 - OpenFeign: https://github.com/OpenFeign/feign

--- a/src/main/java/org/bonitasoft/web/client/api/ArchivedProcessInstanceDocumentApi.java
+++ b/src/main/java/org/bonitasoft/web/client/api/ArchivedProcessInstanceDocumentApi.java
@@ -62,10 +62,10 @@ public interface ArchivedProcessInstanceDocumentApi extends ApiClient.Api {
      * &#x60;archivedCaseId&#x3D;\&quot;id\&quot;&#x60;: search for documents with the specified archived process instance id. *
      * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier. *
      * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * 
      * @param p index of the page to display (required)
@@ -90,10 +90,10 @@ public interface ArchivedProcessInstanceDocumentApi extends ApiClient.Api {
      * &#x60;archivedCaseId&#x3D;\&quot;id\&quot;&#x60;: search for documents with the specified archived process instance id. *
      * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier. *
      * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * 
      * @param p index of the page to display (required)
@@ -117,10 +117,10 @@ public interface ArchivedProcessInstanceDocumentApi extends ApiClient.Api {
      * &#x60;archivedCaseId&#x3D;\&quot;id\&quot;&#x60;: search for documents with the specified archived process instance id. *
      * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier. *
      * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * Note, this is equivalent to the other <code>searchArchivedProcessInstanceDocuments</code> method,
      * but with the query parameters collected into a single Map parameter. This
@@ -154,10 +154,10 @@ public interface ArchivedProcessInstanceDocumentApi extends ApiClient.Api {
      * &#x60;archivedCaseId&#x3D;\&quot;id\&quot;&#x60;: search for documents with the specified archived process instance id. *
      * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier. *
      * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * Note, this is equivalent to the other <code>searchArchivedProcessInstanceDocuments</code> that receives the query parameters as a map,
      * but this one also exposes the Http response headers

--- a/src/main/java/org/bonitasoft/web/client/api/ProcessInstanceDocumentApi.java
+++ b/src/main/java/org/bonitasoft/web/client/api/ProcessInstanceDocumentApi.java
@@ -128,10 +128,10 @@ public interface ProcessInstanceDocumentApi extends ApiClient.Api {
      * Finds ProcessInstanceDocuments with pagination params and filters It is possible to filter on three parameters: &#x60;submittedBy&#x60;, &#x60;name&#x60; and
      * &#x60;description&#x60;. * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier.
      * * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * 
      * @param p index of the page to display (required)
@@ -153,10 +153,10 @@ public interface ProcessInstanceDocumentApi extends ApiClient.Api {
      * Finds ProcessInstanceDocuments with pagination params and filters It is possible to filter on three parameters: &#x60;submittedBy&#x60;, &#x60;name&#x60; and
      * &#x60;description&#x60;. * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier.
      * * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * 
      * @param p index of the page to display (required)
@@ -177,10 +177,10 @@ public interface ProcessInstanceDocumentApi extends ApiClient.Api {
      * Finds ProcessInstanceDocuments with pagination params and filters It is possible to filter on three parameters: &#x60;submittedBy&#x60;, &#x60;name&#x60; and
      * &#x60;description&#x60;. * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier.
      * * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * Note, this is equivalent to the other <code>searchProcessInstanceDocuments</code> method,
      * but with the query parameters collected into a single Map parameter. This
@@ -211,10 +211,10 @@ public interface ProcessInstanceDocumentApi extends ApiClient.Api {
      * Finds ProcessInstanceDocuments with pagination params and filters It is possible to filter on three parameters: &#x60;submittedBy&#x60;, &#x60;name&#x60; and
      * &#x60;description&#x60;. * &#x60;submittedBy&#x3D;\&quot;id\&quot;&#x60;: search for documents that were submitted by the user with the specified identifier.
      * * &#x60;name&#x3D;\&quot;string\&quot;&#x60;: search for documents with names that contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the name or the start of a word in the name. * &#x60;description&#x3D;\&quot;string\&quot;&#x60;: search for documents with descriptions that
      * contain _string_. Depending on the setting for [word-based
-     * search](https://documentation.bonitasoft.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
+     * search](https://documentation.ofelia.com/bonita/latest/api/using-list-and-search-methods#word_based_search), the search returns documents with _string_
      * at the start of the description or the start of a word in the description.
      * Note, this is equivalent to the other <code>searchProcessInstanceDocuments</code> that receives the query parameters as a map,
      * but this one also exposes the Http response headers


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft -> Ofelia rebranding.